### PR TITLE
CKS-353 Improve build times with parallel tests, mounted volume and warning level logging

### DIFF
--- a/functional-tests/docker-compose.yml
+++ b/functional-tests/docker-compose.yml
@@ -33,6 +33,8 @@ services:
     container_name: cks-web-app
     ports:
       - "8080:8080"
+    volumes:
+      - ./../web-app/publish:/app
 
 networks:
   default:

--- a/functional-tests/docker-compose.yml
+++ b/functional-tests/docker-compose.yml
@@ -1,27 +1,14 @@
 version: "3.7"
 services:
   selenium-hub:
-    image: selenium/hub:3.141.59-zirconium
+    image: selenium/hub:3.141.59-20200525
     container_name: selenium-hub
     ports:
       - "4444:4444"
 
   selenium-chrome:
-    image: selenium/node-chrome:3.141.59-zirconium
-    container_name: selenium-chrome
-    volumes:
-      - /dev/shm:/dev/shm
-    depends_on:
-      - selenium-hub
-    environment:
-      - HUB_HOST=selenium-hub
-      - HUB_PORT=4444
-
-  selenium-firefox:
-    image: selenium/node-firefox:3.141.59-zirconium
-    container_name: selenium-firefox
-    volumes:
-      - /dev/shm:/dev/shm
+    image: selenium/node-chrome:3.141.59-20200525
+    shm_size: "1gb"
     depends_on:
       - selenium-hub
     environment:

--- a/functional-tests/docker-run.sh
+++ b/functional-tests/docker-run.sh
@@ -11,7 +11,7 @@ export COMPOSE_CONVERT_WINDOWS_PATHS=1
 
 # Clean up before starting containers
 docker-compose down --remove-orphans --volumes && docker-compose rm -vf
-docker-compose up -d
+docker-compose up -d --scale selenium-chrome=5
 
 # Wait for the web app to be up before running the tests
 docker-compose run -T test-runner npm run wait-then-test

--- a/functional-tests/wdio.conf.js
+++ b/functional-tests/wdio.conf.js
@@ -24,7 +24,7 @@ exports.config = {
 	coloredLogs: true,
 	screenshotPath: "./screenshots/",
 	baseUrl: "http://localhost:5000/",
-	reporters: isTeamCity ? ["spec", "teamcity"] : ["spec"],
+	reporters: isTeamCity ? ["spec", "teamcity", "allure"] : ["spec"],
 
 	// Use BDD with Cucumber
 	framework: "cucumber",

--- a/functional-tests/wdio.conf.js
+++ b/functional-tests/wdio.conf.js
@@ -5,7 +5,7 @@ const isInDocker = !!process.env.IN_DOCKER,
 
 exports.config = {
 	sync: true,
-	maxInstances: isInDocker ? 5 : 2,
+	maxInstances: isInDocker ? 10 : 2,
 	services: isInDocker ? [] : ["selenium-standalone"],
 	seleniumLogs: "./logs",
 
@@ -15,20 +15,16 @@ exports.config = {
 		{
 			browserName: "chrome",
 			chromeOptions: {
-				args: ["--window-size=1366,768"],
+				args: ["--window-size=1366,768"].concat(isInDocker ? "--headless" : []),
 			},
 		},
-		//Disabled firefox tests as there is a card open to fix them: CKS-301
-		// {
-		// 	browserName: "firefox",
-		// },
 	],
 
 	logLevel: "error",
 	coloredLogs: true,
 	screenshotPath: "./screenshots/",
 	baseUrl: "http://localhost:5000/",
-	reporters: isTeamCity ? ["spec", "teamcity", "allure"] : ["spec"],
+	reporters: isTeamCity ? ["spec", "teamcity"] : ["spec"],
 
 	// Use BDD with Cucumber
 	framework: "cucumber",

--- a/web-app/CKS.Web/appsettings.json
+++ b/web-app/CKS.Web/appsettings.json
@@ -10,12 +10,10 @@
     "RabbitMQExchangeName": "logging.application.serilog",
     "RabbitMQExchangeType": "topic",
     "SerilogFilePath": "Serilog-{Date}.json",
-    "SerilogMinLevel": "Debug",
+    "SerilogMinLevel": "Warning",
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Warning"
     },
     "UseRabbit": false,
     "UseFile": true

--- a/web-app/Dockerfile
+++ b/web-app/Dockerfile
@@ -4,9 +4,7 @@ ENV ASPNETCORE_URLS http://+:8080
 
 WORKDIR /app
 
-# Assume the CKS .NET Core app has been published into the /web-app/publish folder
-COPY ./publish ./
-
 EXPOSE 8080
 
+# Make sure yout mount a volume into the /app folder
 ENTRYPOINT ["dotnet", "CKS.Web.dll"]


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/CKS-353

This PR does 3 things in an attempt to improve build times:

1. Increases default logging level for the wrapper web app from debug to warning. .NET console logging is slow and at the debug level the tests were logging something for every single request as it looked through redirects etc, so this was slow for 2 reasons: because the logging itself is slow and because we copy the logs out of docker, which were getting towards being 70Mb (yes!).
2. Mounting a volume into docker. Which should be quicker than copying the dir.
3. Running the tests in parallel by using the docker compose --scale option to scale the selenium chrome node within the docker network

