### PR TITLE
CKS-371 Comment out removeServerHeader

### DIFF
--- a/web-app/CKS.Web/web.config
+++ b/web-app/CKS.Web/web.config
@@ -34,7 +34,8 @@
 			</customHeaders>
 		</httpProtocol>
 		<security>
-			<requestFiltering removeServerHeader="true" />
+			<!-- TODO: Reinstate removeServerHeader when we've upgraded to IIS 10 -->
+			<!-- <requestFiltering removeServerHeader="true" /> -->
 		</security>
 	</system.webServer>
 </configuration>


### PR DESCRIPTION
IIS 8.5 doesn't support removeServerHeader so we're removing it
until we upgrade to IIS10

https://nicedigital.atlassian.net/browse/CKS-371