### PR TITLE
CKS-398 Remove precached pages from SW

### DIFF
--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -105,15 +105,6 @@ module.exports = {
 		{
 			resolve: `gatsby-plugin-offline`,
 			options: {
-				precachePages: [
-					`/specialities/`,
-					`/specialities/*`,
-					`/about/`,
-					`/about/development/`,
-					`/topics/`,
-					`/topics/*`,
-					`/search/`,
-				],
 				workboxConfig: {
 					// Use the default gatsby runtimeCaching with 2 key differences:
 					// use NetworkFirst for page-data.json and for HTML pages


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/CKS-398

We precache various pages, see https://github.com/nice-digital/cks-gatsby/blob/master/gatsby/gatsby-config.js#L108-L116. However, this means a lot of upfront background loading which seems to slow down the browser. It also doesn't add much because it's still not pre caching the actual useful topic content like diagnosis, management and prescribing. So we might as well remove the precaching and explore the idea of letting a user select topics to precache. Removing precaching still means the SW will do runtime caching as a user navigates.