### PR TITLE
CKS-489 Fix preload attribute

### DIFF
--- a/web-app/CKS.Web/web.config
+++ b/web-app/CKS.Web/web.config
@@ -100,7 +100,7 @@
 		<httpProtocol>
 			<customHeaders>
 				<remove name="X-Powered-By" />
-				<add name="Link" value="&lt;https://apikeys.civiccomputing.com&gt;; rel=preconnect; crossorigin,&lt;https://www.googletagmanager.com&gt;; rel=preconnect,&lt;https://cdn.nice.org.uk/cookie-banner/cookie-banner.min.js&gt;; rel=preload; as=script&gt;"/>
+				<add name="Link" value="&lt;https://apikeys.civiccomputing.com&gt;; rel=preconnect; crossorigin,&lt;https://www.googletagmanager.com&gt;; rel=preconnect,&lt;https://cdn.nice.org.uk/cookie-banner/cookie-banner.min.js&gt;; rel=preload; as=script"/>
 				<add name="X-Frame-Options" value="SAMEORIGIN" />
 				<add name="X-Xss-Protection" value="1; mode=block" />
 				<add name="X-Content-Type-Options" value="nosniff" />


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/CKS-489
Chrome was reporting <link rel=preload> must have a valid `as` value
because of an extra less than sign