### PR TITLE
CKS-588 Push referrer in routechange

### DIFF
--- a/gatsby/gatsby-browser.ts
+++ b/gatsby/gatsby-browser.ts
@@ -26,7 +26,7 @@ export const onRouteUpdate = ({
 		// AND because it doesn't use requestAnimationFrame to delay until the page title has been updated
 
 		const sendPageView = () => {
-			window.dataLayer.push({ location: location.href });
+			window.dataLayer.push({ location: location.href, 'referrer': prevLocation });
 			// Don't consider hash changes to be a page view - pageviews only happy when the path changes
 			if (prevPath != path) window.dataLayer.push({ event: "pageview" });
 		};
@@ -42,7 +42,7 @@ export const onRouteUpdate = ({
 			setTimeout(sendPageView, 32);
 		}
 	} else {
-		window.dataLayer.push({ location: location.href });
+		window.dataLayer.push({ location: location.href, 'referrer': document.referrer });
 	}
 };
 


### PR DESCRIPTION
Push prevLocation as the referrer to the dataLayer along with location. Where prevLocation is undefined/falsey send document.referrer

https://nicedigital.atlassian.net/browse/CKS-588